### PR TITLE
자유게시판 게시글 수정, 삭제

### DIFF
--- a/wtwiProject/src/main/java/com/wtwi/fin/freeboard/controller/BoardController.java
+++ b/wtwiProject/src/main/java/com/wtwi/fin/freeboard/controller/BoardController.java
@@ -1,5 +1,6 @@
 package com.wtwi.fin.freeboard.controller;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -143,13 +144,108 @@ public class BoardController {
 		String path;
 		if(freeNo>0) { // 삽입 성공
 			path = "redirect:"+freeNo;
-			MemberController.swalSetMessage(ra, "success", "게시글이 성공적으로 작성되었습니다.", null);
+			MemberController.swalSetMessage(ra, "success", "게시글이 작성되었습니다.", null);
 		
 		} else { // 삽입 실패
 			path = "redirect:"+request.getHeader("referer");
-			MemberController.swalSetMessage(ra, "success", "게시글 작성에 실패하였습니다.", null);
+			MemberController.swalSetMessage(ra, "error", "게시글 작성에 실패하였습니다.", null);
 		}
 		return path;
 	}
+
+	// 자유게시판 게시글 삭제(10)
+	@RequestMapping(value="delete", method=RequestMethod.POST)
+	public String deleteBoard(@RequestParam(value="cp", required=false, defaultValue="1") int cp,
+							  @RequestParam("freeNo") int freeNo,
+							  RedirectAttributes ra,
+							  HttpServletRequest request) {
+		
+		int result = service.deleteBoard(freeNo);
+		
+		String path;
+		if(result>0) { // 삭제 성공
+			path = "redirect:list";
+			MemberController.swalSetMessage(ra, "success", "게시글이 삭제되었습니다.", null);
+		
+		} else { // 삭제 실패
+			path = "redirect:"+request.getHeader("referer");
+			MemberController.swalSetMessage(ra, "error", "게시글 삭제에 실패하였습니다.", null);
+		}
+		return path;
+	}
+	
+	// 자유게시판 게시글 수정 화면 전환(11)
+	@RequestMapping(value="updateForm", method=RequestMethod.POST)
+	public String updateForm(@RequestParam("freeNo") int freeNo,
+							 Model model) {
+		
+		// 카테고리 목록 조회
+		List<Category> category = service.selectCategory();
+		
+		// 게시글 상세 조회
+		Board board = service.selectBoard(freeNo);
+		
+		model.addAttribute("category", category);
+		model.addAttribute("board", board);
+		
+		return "freeboard/boardUpdate";
+	}
+	
+	// 자유게시판 게시글 수정 화면 이미지 삭제 시(12)
+	@ResponseBody
+	@RequestMapping(value="deleteImage", method=RequestMethod.POST)
+	public String deleteFile(@RequestParam("src") String src) {
+		
+		// src에서 파일명 추출해 반환
+		String[] arr = src.split("/");
+		String fileName = null;
+		for(int i=arr.length-1; i>=arr.length-1; i--) {
+			fileName = arr[i];
+		}
+		fileName = "resources/images/freeboard/"+ fileName;
+		
+		return fileName;
+	}
+	
+	// 자유게시판 게시글 수정(13)
+	@RequestMapping(value="update", method=RequestMethod.POST)
+	public String updateBoard(@ModelAttribute Board board,
+							  @RequestParam("editordata") String freeContent,
+							  @RequestParam("imgs") List<String> imgs,
+							  @RequestParam("deleteImgs") List<String> deleteImgs,
+							  RedirectAttributes ra, 
+							  HttpServletRequest request) {
+		
+		board.setFreeContent(freeContent);
+		
+		String webPath = "resources/images/freeboard/";
+		
+		//for(String s1 : imgs) System.out.println("imgs : "+s1);
+		//for(String s2 : deleteImgs) System.out.println("deleteImgs : "+s2);
+		
+		// 게시글 수정(13)
+		int result = service.updateBoard(board, imgs, deleteImgs, webPath, request);
+		
+		String path;
+		if(result>0) { // 수정 성공
+			path = "redirect:"+board.getFreeNo();
+			MemberController.swalSetMessage(ra, "success", "게시글이 수정되었습니다.", null);
+			
+		} else { // 수정 실패
+			path = "redirect:"+request.getHeader("referer");
+			MemberController.swalSetMessage(ra, "error", "게시글 수정에 실패하였습니다.", null);
+		}
+		return path;
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
 	
 }

--- a/wtwiProject/src/main/java/com/wtwi/fin/freeboard/exception/DeleteFileException.java
+++ b/wtwiProject/src/main/java/com/wtwi/fin/freeboard/exception/DeleteFileException.java
@@ -1,0 +1,9 @@
+package com.wtwi.fin.freeboard.exception;
+
+// 사용자 정의 예외
+public class DeleteFileException extends RuntimeException {
+
+	public DeleteFileException() {
+		super("삭제된 이미지 파일을 서버에서 삭제하는 과정에서 문제 발생");
+	}
+}

--- a/wtwiProject/src/main/java/com/wtwi/fin/freeboard/model/dao/BoardDAO.java
+++ b/wtwiProject/src/main/java/com/wtwi/fin/freeboard/model/dao/BoardDAO.java
@@ -109,5 +109,29 @@ public class BoardDAO {
 	public List<String> selectDbList(String standard) {
 		return sqlSession.selectList("freeboardMapper.selectDbList", standard);
 	}
+
+	/** 게시글 삭제(10)
+	 * @param freeNo
+	 * @return result
+	 */
+	public int deleteBoard(int freeNo) {
+		return sqlSession.update("freeboardMapper.deleteBoard", freeNo);
+	}
+
+	/** 게시글 수정(13-1)
+	 * @param board
+	 * @return result
+	 */
+	public int updateBoard(Board board) {
+		return sqlSession.update("freeboardMapper.updateBoard", board);
+	}
+
+	/** 삭제된 이미지 정보 DB에서 제거(13-3)
+	 * @param deleteImages
+	 * @return 
+	 */
+	public int deleteImages(List<Image> deleteImages) {
+		return sqlSession.delete("freeboardMapper.deleteImages", deleteImages);
+	}
 	
 }

--- a/wtwiProject/src/main/java/com/wtwi/fin/freeboard/model/service/BoardService.java
+++ b/wtwiProject/src/main/java/com/wtwi/fin/freeboard/model/service/BoardService.java
@@ -2,6 +2,8 @@ package com.wtwi.fin.freeboard.model.service;
 
 import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.web.multipart.MultipartFile;
 
 import com.wtwi.fin.freeboard.model.vo.Board;
@@ -72,5 +74,21 @@ public interface BoardService {
 	 * @return dbList
 	 */
 	List<String> selectDbList(String standard);
+
+	/** 게시글 삭제(10)
+	 * @param freeNo
+	 * @return result
+	 */
+	int deleteBoard(int freeNo);
+
+	/** 게시글 수정(13)
+	 * @param board
+	 * @param imgs
+	 * @param deleteImgs
+	 * @param webPath
+	 * @param request 
+	 * @return result
+	 */
+	int updateBoard(Board board, List<String> imgs, List<String> deleteImgs, String webPath, HttpServletRequest request);
 
 }

--- a/wtwiProject/src/main/resources/mappers/freeboard-mapper.xml
+++ b/wtwiProject/src/main/resources/mappers/freeboard-mapper.xml
@@ -155,4 +155,28 @@
 		WHERE SUBSTR(FILE_NM, 0, 10) <![CDATA[ < ]]> #{standard}
 	</select>
 	
+	<!-- 게시글 삭제(10) -->
+	<update id="deleteBoard" parameterType="_int">
+		UPDATE FREE_BOARD SET
+		FREE_STATUS='N'
+		WHERE FREE_NO = #{freeNo}
+	</update>
+	
+	<!-- 게시글 수정(13-1) -->
+	<update id="updateBoard" parameterType="FreeBoard">
+		UPDATE FREE_BOARD SET
+		FREE_CATEGORY_NO = ${freeCategoryNo}, FREE_TITLE = #{freeTitle}, FREE_CONTENT = #{freeContent}
+		WHERE FREE_NO = #{freeNo}
+	</update>
+	
+	<!-- 삭제된 이미지 정보 DB에서 제거(13-3) -->
+	<delete id="deleteImages" parameterType="list">
+		DELETE FROM FREE_IMAGE
+		WHERE FILE_NM IN (
+		<foreach collection="list" item="i" separator=",">
+			#{i.fileName}
+		</foreach>
+		)
+	</delete>
+	
 </mapper>

--- a/wtwiProject/src/main/webapp/WEB-INF/views/freeboard/boardUpdate.jsp
+++ b/wtwiProject/src/main/webapp/WEB-INF/views/freeboard/boardUpdate.jsp
@@ -13,7 +13,7 @@
 <jsp:include page="../common/header.jsp" />
     <div class="container">
         <h3 class="my-4 font-weight-bold">자유게시판</h3>
-        <form action="insert" method="POST" id="insertForm">
+        <form action="update" method="POST" id="updateForm">
             <div class="row mb-3">
 	            <div class="col-2">
 	                <select class="form-control" id="freeCategory" name="freeCategoryNo">
@@ -23,13 +23,15 @@
 	                </select>
 	            </div>
 	            <div class="col-10">
-	                <input type="text" class="form-control" placeholder="제목을 입력하세요." id="freeTitle" name="freeTitle">
+	                <input type="text" class="form-control" value="${board.freeTitle}" id="freeTitle" name="freeTitle">
 	            </div>
             </div>
             <div class="mb-3">
-                <textarea id="summernote" name="editordata"></textarea>
+                <textarea id="summernote" name="editordata">${board.freeContent}</textarea>
             </div>
             <input type="hidden" name="imgs" id="imgs">
+            <input type="hidden" name="deleteImgs" id="deleteImgs">
+            <input type="hidden" name="freeNo" value="${board.freeNo}">
             <button type="button" class="btn btn-outline-secondary" onclick="">취소</button>
             <button type="submit" class="btn btn-secondary float-right">등록</button>
         </form>
@@ -37,6 +39,7 @@
 </body>
 <script>
 var imgs = [];
+var deleteImgs = [];
 
 $(document).ready(function() {
 	$('#summernote').summernote({
@@ -64,6 +67,11 @@ $(document).ready(function() {
 				for(var i=files.length-1; i>=0; i--){
 					uploadFile(files[i], this);
 				}
+			},
+			
+			onMediaDelete: function(target){
+				//console.log(target[0].src);
+				deleteFile(target[0].src);
 			}
 		}
 	});
@@ -74,7 +82,6 @@ $(document).ready(function() {
 	     $(this).summernote("pasteHTML", "<br><br>");
 	     e.preventDefault();
 	});
-
        
 	function uploadFile(file, el){
 		data = new FormData();
@@ -89,7 +96,7 @@ $(document).ready(function() {
 			processData: false,
            	
 			success: function(fileName) {
-				//console.log(fileName);
+				console.log(fileName);
 				imgs.push(fileName);
 				var image = "${contextPath}/"+fileName;
 				$(el).summernote('editor.insertImage', image, function($image){
@@ -106,8 +113,25 @@ $(document).ready(function() {
 		});
 	}
 	
+	function deleteFile(src){
+		$.ajax({
+			url : "${contextPath}/freeboard/deleteImage",
+			type : "POST",
+			data : {"src" : src},
+			cache: false,
+	        
+			success: function(fileName){
+				deleteImgs.push(fileName);
+			},
+			
+			error: function(e){
+				console.log(e);
+			}
+		});
+	}
+	
 	// 유효성 검사
-	$("#insertForm").on("submit", function(){
+	$("#updateForm").on("submit", function(){
 		if($("#freeTitle").val().trim().length==0){
 			swal({
 				icon:"warning",
@@ -125,7 +149,17 @@ $(document).ready(function() {
 			return false;
 		}
 		$("#imgs").val(imgs);
+		$("#deleteImgs").val(deleteImgs);
 	});
+	
+	// 카테고리 선택
+	const freeCategoryName = "${board.freeCategoryName}";
+	$("#freeCategory > option").each(function(index, item){
+		if($(item).text()==freeCategoryName){
+			$(item).prop("selected", true);
+		}
+	});
+	
 });
 </script>
 </html>

--- a/wtwiProject/src/main/webapp/WEB-INF/views/freeboard/boardView.jsp
+++ b/wtwiProject/src/main/webapp/WEB-INF/views/freeboard/boardView.jsp
@@ -34,15 +34,15 @@
                 <div class="col-10">${board.freeTitle}</div>
                 <div class="free-menu col-1">
                 	<c:if test="${!empty loginMember }">
-	                    <a class="btn dropdown-toggle" type="button" id="dropdownMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+	                    <a class="dropdown-toggle" type="button" id="dropdownMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 	                    	<i class="bi bi-three-dots"></i>
 	                    </a>
                     </c:if>
 					<div class="dropdown-menu" aria-labelledby="dropdownMenu">
 						<c:choose>
 							<c:when test="${board.memberNo == loginMember.memberNo }">
-								<button class="dropdown-item" type="button">수정</button>
-								<button class="dropdown-item" type="button">삭제</button>
+								<button class="dropdown-item" type="button" onclick="fnRequest('updateForm');">수정</button>
+								<button class="dropdown-item" type="button" onclick="deleteAlert();">삭제</button>
 							</c:when>
 							<c:otherwise>
 								<button class="dropdown-item" type="button">신고</button>
@@ -93,8 +93,28 @@
         <button class="btn btn-outline-secondary mt-2" onclick="">이전 목록</button>
     </div>
 <!-- footer include -->
+<form action="#" method="POST" name="requestForm">
+	<input type="hidden" name="freeNo" value="${board.freeNo}">
+	<input type="hidden" name="cp" value="${param.cp}">
+</form>
 <script>
-
+function fnRequest(addr){
+	document.requestForm.action = addr;
+	document.requestForm.submit();
+}
+// 삭제시 알림창 띄우기
+function deleteAlert(){
+	swal({
+		icon: "warning",
+		title: "게시글을 삭제하시겠습니까?",
+		buttons: ["취소", "삭제"],
+		dangerMode: true,
+	}).then((willDelete) => {
+		if (willDelete) {
+			onclick=fnRequest("delete");
+		} 
+	});
+}
 </script>
 </body>
 </html>

--- a/wtwiProject/target/classes/mappers/freeboard-mapper.xml
+++ b/wtwiProject/target/classes/mappers/freeboard-mapper.xml
@@ -155,4 +155,28 @@
 		WHERE SUBSTR(FILE_NM, 0, 10) <![CDATA[ < ]]> #{standard}
 	</select>
 	
+	<!-- 게시글 삭제(10) -->
+	<update id="deleteBoard" parameterType="_int">
+		UPDATE FREE_BOARD SET
+		FREE_STATUS='N'
+		WHERE FREE_NO = #{freeNo}
+	</update>
+	
+	<!-- 게시글 수정(13-1) -->
+	<update id="updateBoard" parameterType="FreeBoard">
+		UPDATE FREE_BOARD SET
+		FREE_CATEGORY_NO = ${freeCategoryNo}, FREE_TITLE = #{freeTitle}, FREE_CONTENT = #{freeContent}
+		WHERE FREE_NO = #{freeNo}
+	</update>
+	
+	<!-- 삭제된 이미지 정보 DB에서 제거(13-3) -->
+	<delete id="deleteImages" parameterType="list">
+		DELETE FROM FREE_IMAGE
+		WHERE FILE_NM IN (
+		<foreach collection="list" item="i" separator=",">
+			#{i.fileName}
+		</foreach>
+		)
+	</delete>
+	
 </mapper>


### PR DESCRIPTION
1. 삭제
-- 게시글 본문 상단의 토글의 드롭다운 메뉴에서 삭제 버튼 클릭시 진행
-- 삭제 알림창을 띄운 뒤 삭제 버튼은 누르면 최종 삭제
2. 수정
-- 이미지를 새로 첨부할 때마다 서버에 저장되며 최종 수정시 DB에 컬럼 추가
-- 이미지 삭제(이미지 클릭 후 휴지통버튼 클릭으로만 동작, 백스페이스나 delete시 동작하지 않음...)
--> 최종 수정시 서버의 해당 이미지 삭제 및 DB에서도 해당 컬럼 삭제
