### PR TITLE
자유게시판 작성/수정화면 두 줄 개행 문제 수정

### DIFF
--- a/wtwiProject/src/main/webapp/WEB-INF/views/freeboard/boardInsert.jsp
+++ b/wtwiProject/src/main/webapp/WEB-INF/views/freeboard/boardInsert.jsp
@@ -71,7 +71,7 @@ $(document).ready(function() {
 	// summernote에서는 enter 를 할 때마다 작성한 문자들이 <p> 태그로 감싸지게 되고
 	// 일반적인 줄바꿈(<br>)은 shift+enter로 동작한다. <p> 태그로 감싸지는 것을 바꿔줌
 	$("#summernote").on("summernote.enter", function(we, e) {
-	     $(this).summernote("pasteHTML", "<br><br>");
+	     $(this).summernote("pasteHTML", "<br>&zwnj;");
 	     e.preventDefault();
 	});
 

--- a/wtwiProject/src/main/webapp/WEB-INF/views/freeboard/boardUpdate.jsp
+++ b/wtwiProject/src/main/webapp/WEB-INF/views/freeboard/boardUpdate.jsp
@@ -89,7 +89,7 @@ $(document).ready(function() {
 	// summernote에서는 enter 를 할 때마다 작성한 문자들이 <p> 태그로 감싸지게 되고
 	// 일반적인 줄바꿈(<br>)은 shift+enter로 동작한다. <p> 태그로 감싸지는 것을 바꿔줌
 	$("#summernote").on("summernote.enter", function(we, e) {
-	     $(this).summernote("pasteHTML", "<br><br>");
+	     $(this).summernote("pasteHTML", "<br>&zwnj;");
 	     e.preventDefault();
 	});
        


### PR DESCRIPTION
기존 \<p\> 태그로 단락이 감싸지던 문제를 \<br\>로 감싸면서 두 줄씩 개행이 되었는데 
이를 단락이 \<br\>과 \&zwnj; 로 감싸지게 바꾸었음
 \&zwnj; 은 매우 얇은 접합자로 summernote.js 파일을 건드리지 않으면서 
문제를 해결하는 최선의 방법이라고 생각함.... (완전 해결은 아님 !)
출처는 : https://github.com/summernote/summernote/issues/546